### PR TITLE
Bump OpenGL upper bound

### DIFF
--- a/GLFW-b-demo.cabal
+++ b/GLFW-b-demo.cabal
@@ -39,7 +39,7 @@ executable GLFW-b-demo
 
   build-depends:
     GLFW-b       == 1.4.*,
-    OpenGL       >= 2.8 && < 2.10,
+    OpenGL       >= 2.8 && < 2.12,
     base          < 5,
     mtl          == 2.1.*,
     pretty       == 1.1.*,


### PR DESCRIPTION
Works with the following package versions on linux:

```
    GLFW-b-1.4.7.1
    bindings-GLFW-3.1.1
    OpenGL-2.11.1.0
    OpenGLRaw-2.3.0.0
```

after `bindings-GLFW` is fixed according to https://github.com/bsl/bindings-GLFW/issues/20.
